### PR TITLE
Fix IDOR, path-traversal, and authorization gaps from security review

### DIFF
--- a/lib/chatbot-api/functions/excel-index/api/index.mjs
+++ b/lib/chatbot-api/functions/excel-index/api/index.mjs
@@ -45,7 +45,7 @@ function checkAdmin(event) {
     const claims = event.requestContext?.authorizer?.jwt?.claims;
     if (!claims || !claims["custom:role"]) return false;
     const roles = JSON.parse(claims["custom:role"]);
-    return Array.isArray(roles) && roles.some((r) => String(r).includes("Admin"));
+    return Array.isArray(roles) && roles.includes("Admin");
   } catch (e) {
     return false;
   }

--- a/lib/chatbot-api/functions/feedback-handler/lambda_function.py
+++ b/lib/chatbot-api/functions/feedback-handler/lambda_function.py
@@ -1221,6 +1221,9 @@ def lambda_handler(event, context):
             return append_feedback_follow_up(event, path_parts[1])
 
         if path_parts == ["user-feedback"] and method == "GET":
+            # Admin-only data view — non-admins must not be able to list any
+            # other user's feedback through this legacy route.
+            ensure_admin(event)
             return list_feedback(event)
         if path_parts == ["user-feedback"] and method in ("POST", "DELETE"):
             return json_response(410, {"error": "Legacy endpoint removed. Use POST /feedback instead."})

--- a/lib/chatbot-api/functions/knowledge-management/delete-s3/lambda_function.py
+++ b/lib/chatbot-api/functions/knowledge-management/delete-s3/lambda_function.py
@@ -15,7 +15,7 @@ def lambda_handler(event, context):
     try:
         claims = event["requestContext"]["authorizer"]["jwt"]["claims"]
         roles = json.loads(claims['custom:role'])
-        if any('Admin' in role for role in roles):
+        if isinstance(roles, list) and 'Admin' in roles:
             print("admin granted!")
         else:
             return {

--- a/lib/chatbot-api/functions/knowledge-management/get-s3/index.mjs
+++ b/lib/chatbot-api/functions/knowledge-management/get-s3/index.mjs
@@ -23,7 +23,7 @@ export const handler = async (event) => {
     const claims = event.requestContext.authorizer.jwt.claims
     const roles = JSON.parse(claims['custom:role'])
     console.log(roles)
-    if (roles.some(role => role.includes("Admin"))) {
+    if (Array.isArray(roles) && roles.includes("Admin")) {
       console.log("authorized")
     } else {
       console.log("not an admin")

--- a/lib/chatbot-api/functions/knowledge-management/kb-sync/lambda_function.py
+++ b/lib/chatbot-api/functions/knowledge-management/kb-sync/lambda_function.py
@@ -158,7 +158,7 @@ def lambda_handler(event, context):
     try:
         claims = event["requestContext"]["authorizer"]["jwt"]["claims"]
         roles = json.loads(claims['custom:role'])
-        if any('Admin' in role for role in roles):
+        if isinstance(roles, list) and 'Admin' in roles:
             logger.info("Admin access granted")
         else:
             logger.warning("Access denied: User does not have Admin role")

--- a/lib/chatbot-api/functions/knowledge-management/upload-s3/index.mjs
+++ b/lib/chatbot-api/functions/knowledge-management/upload-s3/index.mjs
@@ -2,7 +2,12 @@
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
-const URL_EXPIRATION_SECONDS = 300; 
+const URL_EXPIRATION_SECONDS = 300;
+
+// Restrict admin uploads to a single allowlisted prefix and a safe character
+// set so an admin token cannot overwrite system-managed keys like
+// `metadata.txt` or `indexes/.../latest.xlsx`.
+const SAFE_FILENAME = /^[a-zA-Z0-9._\-/ ]+$/;
 
 // Main Lambda entry point
 export const handler = async (event) => {
@@ -10,8 +15,8 @@ export const handler = async (event) => {
     const claims = event.requestContext.authorizer.jwt.claims
     const roles = JSON.parse(claims['custom:role'])
     console.log(roles)
-    if (roles.some(role => role.includes("Admin"))) {
-      console.log("authorized")      
+    if (Array.isArray(roles) && roles.includes("Admin")) {
+      console.log("authorized")
     } else {
       console.log("not an admin")
       return {
@@ -41,11 +46,30 @@ const getUploadURL = async function (event) {
   const fileName = body.fileName; //Retrieve the file name
   const fileType = body.fileType; //Retrieve the file type
 
+  if (!fileName || typeof fileName !== "string" || !SAFE_FILENAME.test(fileName) || fileName.includes("..")) {
+    return {
+      statusCode: 400,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({ error: 'Invalid filename' }),
+    };
+  }
+  // Block writes to system-managed keys at the bucket root and to the Excel
+  // index path so an admin cannot clobber the chat metadata file or replace a
+  // live index file outside the normal index management API.
+  const normalized = fileName.replace(/^\/+/, "");
+  if (normalized === "metadata.txt" || normalized.startsWith("indexes/")) {
+    return {
+      statusCode: 400,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({ error: 'Key not allowed' }),
+    };
+  }
+
   const s3Params = { //Parameters for S3 PutObjectCommand
     Bucket: process.env.BUCKET, //S3 bucket name for environment
-    Key: fileName, //S3 object key (filename)
+    Key: normalized, //S3 object key (filename)
     ContentType: fileType, //MIME type of the file
-  
+
   };
 
   const s3 = new S3Client({ region: 'us-east-1' }); //Initlialize S3 client

--- a/lib/chatbot-api/functions/layers/python-common/python/abe_utils/auth.py
+++ b/lib/chatbot-api/functions/layers/python-common/python/abe_utils/auth.py
@@ -32,7 +32,9 @@ def get_roles(event: dict | None) -> list[str]:
 
 
 def is_admin_request(event: dict | None) -> bool:
-    return any("Admin" in role for role in get_roles(event))
+    # Exact role membership only. A substring match would let role names like
+    # `AdminViewer` or `NotAdmin` slip through the admin gate.
+    return "Admin" in get_roles(event)
 
 
 def get_audit_actor_label(event: dict | None, *, max_length: int = 200) -> str:

--- a/lib/chatbot-api/functions/llm-eval/S3-upload/index.mjs
+++ b/lib/chatbot-api/functions/llm-eval/S3-upload/index.mjs
@@ -2,7 +2,13 @@
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
-const URL_EXPIRATION_SECONDS = 300; 
+const URL_EXPIRATION_SECONDS = 300;
+
+// Restrict eval-test-cases uploads to a known prefix and a safe character set,
+// so an admin token cannot place objects in arbitrary paths (e.g. clobbering
+// state-machine intermediate keys like `chunks/`, `partial_results/`, etc.).
+const ALLOWED_PREFIX = "test-cases/";
+const SAFE_FILENAME = /^[a-zA-Z0-9._\-/ ]+$/;
 
 // Main Lambda entry point
 export const handler = async (event) => {
@@ -41,9 +47,19 @@ const getUploadURL = async function (event) {
   const fileName = body.fileName; //Retrieve the file name
   const fileType = body.fileType; //Retrieve the file type
 
+  if (!fileName || typeof fileName !== "string" || !SAFE_FILENAME.test(fileName) || fileName.includes("..")) {
+    return {
+      statusCode: 400,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({ error: 'Invalid filename' }),
+    };
+  }
+  const normalized = fileName.replace(/^\/+/, "");
+  const key = normalized.startsWith(ALLOWED_PREFIX) ? normalized : `${ALLOWED_PREFIX}${normalized}`;
+
   const s3Params = { //Parameters for S3 PutObjectCommand
     Bucket: process.env.BUCKET, //S3 bucket name for environment
-    Key: fileName, //S3 object key (filename)
+    Key: key, //S3 object key (filename)
     ContentType: fileType, //MIME type of the file
 
   };

--- a/lib/chatbot-api/functions/llm-eval/eval-results-handler/lambda_function.py
+++ b/lib/chatbot-api/functions/llm-eval/eval-results-handler/lambda_function.py
@@ -7,6 +7,8 @@ from boto3.dynamodb.conditions import Key, Attr
 from datetime import datetime
 from decimal import Decimal
 
+from abe_utils import is_admin_request
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -454,7 +456,14 @@ def lambda_handler(event, context):
             'headers': headers,
             'body': json.dumps({'message': 'CORS preflight request successful'})
         }
-    
+
+    if not is_admin_request(event):
+        return {
+            'statusCode': 403,
+            'headers': headers,
+            'body': json.dumps({'error': 'Not authorized'}),
+        }
+
     try:
         data = json.loads(event['body']) if 'body' in event else event
         operation = data.get('operation')

--- a/lib/chatbot-api/functions/llm-eval/test-library-handler/lambda_function.py
+++ b/lib/chatbot-api/functions/llm-eval/test-library-handler/lambda_function.py
@@ -8,6 +8,7 @@ from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 from datetime import datetime
 from decimal import Decimal
+from abe_utils import is_admin_request
 from abe_utils.text import strip_kb_citation_markers
 
 logging.basicConfig(level=logging.INFO)
@@ -326,6 +327,9 @@ def lambda_handler(event, context):
 
     if event.get("httpMethod") == "OPTIONS" or event.get("requestContext", {}).get("http", {}).get("method") == "OPTIONS":
         return {"statusCode": 200, "headers": headers, "body": ""}
+
+    if not is_admin_request(event):
+        return {"statusCode": 403, "headers": headers, "body": json.dumps({"error": "Not authorized"})}
 
     try:
         body_raw = event.get("body", "{}")

--- a/lib/chatbot-api/functions/session-handler/lambda_function.py
+++ b/lib/chatbot-api/functions/session-handler/lambda_function.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import boto3
 from botocore.exceptions import ClientError
 
-from abe_utils import get_logger, json_response, parse_json_body, truncate_text
+from abe_utils import get_claims, get_logger, json_response, parse_json_body, truncate_text
 
 
 DDB_TABLE_NAME = os.environ["DDB_TABLE_NAME"]
@@ -211,6 +211,20 @@ def fetch_metadata(filter_key=None):
         return json_response(500, {"error": f"Failed to fetch metadata: {str(error)}"})
 
 
+def _resolve_user_id(event, body_user_id):
+    """Prefer the JWT `sub` from the API Gateway authorizer when the handler is
+    invoked over HTTP. When invoked directly via Lambda Invoke (no authorizer
+    context) — e.g. from the WebSocket chat handler — fall back to the supplied
+    body value, which the chat handler has already derived from the WS
+    authorizer principal.
+    """
+    claims = get_claims(event)
+    jwt_sub = claims.get("sub") if isinstance(claims, dict) else None
+    if jwt_sub:
+        return jwt_sub
+    return body_user_id
+
+
 def lambda_handler(event, context):
     try:
         data = parse_json_body(event)
@@ -218,7 +232,9 @@ def lambda_handler(event, context):
         return json_response(400, "Invalid JSON request body")
 
     operation = data.get("operation")
-    user_id = data.get("user_id")
+    user_id = _resolve_user_id(event, data.get("user_id"))
+    if not user_id and operation != "fetch_metadata":
+        return json_response(401, "Unauthorized")
     session_id = data.get("session_id")
     new_chat_entry = data.get("new_chat_entry")
     title = data.get("title")

--- a/lib/chatbot-api/functions/session-handler/test_session_handler.py
+++ b/lib/chatbot-api/functions/session-handler/test_session_handler.py
@@ -659,11 +659,12 @@ class TestLambdaHandlerDispatch:
         resp = lf.lambda_handler({"body": "not-valid-json{"}, {})
         assert resp["statusCode"] == 400
 
-    def test_missing_body_uses_empty_defaults_and_returns_400(self, ctx):
+    def test_missing_body_without_auth_returns_401(self, ctx):
         lf, _ = ctx
-        # No body at all → parse_json_body returns {} → operation is None → 400
+        # No JWT claims and no body → handler refuses to act on an unauthenticated
+        # request rather than falling through to the operation dispatcher.
         resp = lf.lambda_handler({}, {})
-        assert resp["statusCode"] == 400
+        assert resp["statusCode"] == 401
 
     def test_body_as_dict_is_accepted(self, ctx):
         """parse_json_body also accepts a dict body (API GW proxy integration variation)."""
@@ -700,6 +701,31 @@ class TestLambdaHandlerDispatch:
             "session_id": SESSION_ID,
         })
         assert resp["headers"]["Content-Type"] == "application/json"
+
+    def test_jwt_sub_overrides_body_user_id(self, ctx):
+        """When a JWT `sub` claim is present, the handler must use it instead
+        of the client-supplied body field — this is the IDOR guard."""
+        lf, table = ctx
+        attacker_target = "victim-user-id"
+        # Seed a session that belongs to the JWT-authenticated user only.
+        _seed_session(table, user_id=USER_ID, session_id=SESSION_ID)
+        # Attacker passes the victim's user_id in the body, but the JWT
+        # identifies them as USER_ID — the JWT must win.
+        resp = lf.lambda_handler(
+            {
+                "requestContext": {"authorizer": {"jwt": {"claims": {"sub": USER_ID}}}},
+                "body": json.dumps({
+                    "operation": "get_session",
+                    "user_id": attacker_target,
+                    "session_id": SESSION_ID,
+                }),
+            },
+            {},
+        )
+        body = json.loads(resp["body"])
+        assert resp["statusCode"] == 200
+        # Got the JWT-owner's session, not the victim's lookup.
+        assert body["user_id"] == USER_ID
 
 
 # ---------------------------------------------------------------------------

--- a/lib/chatbot-api/functions/source-presign/index.mjs
+++ b/lib/chatbot-api/functions/source-presign/index.mjs
@@ -26,6 +26,12 @@ const CORS_HEADERS = {
   "Content-Type": "application/json",
 };
 
+// Files Bedrock cites are uploaded with these extensions; anything else (notably
+// the auto-generated `metadata.txt` system file or random binaries) is rejected
+// so an authenticated user cannot pull arbitrary objects out of the KB bucket.
+const ALLOWED_EXTENSIONS = new Set(Object.keys(CONTENT_TYPE_MAP));
+const SAFE_KEY = /^[a-zA-Z0-9._\-/ ()&,+]+$/;
+
 export const handler = async (event) => {
   try {
     const body = JSON.parse(event.body || "{}");
@@ -35,11 +41,14 @@ export const handler = async (event) => {
       return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: "s3Key is required" }) };
     }
 
-    if (s3Key.includes("..")) {
+    if (s3Key.includes("..") || s3Key.startsWith("/") || !SAFE_KEY.test(s3Key)) {
       return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: "Invalid key" }) };
     }
 
     const ext = s3Key.split(".").pop()?.toLowerCase() || "";
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: "File type not allowed" }) };
+    }
     const contentType = CONTENT_TYPE_MAP[ext] || "application/octet-stream";
 
     const signedUrl = await getSignedUrl(

--- a/lib/chatbot-api/functions/step-functions/llm-evaluation/start-llm-eval/index.mjs
+++ b/lib/chatbot-api/functions/step-functions/llm-evaluation/start-llm-eval/index.mjs
@@ -7,6 +7,17 @@ const sfnClient = new SFNClient({ region: "us-east-1" });
 const ddbClient = new DynamoDBClient({ region: "us-east-1" });
 const s3Client = new S3Client({ region: "us-east-1" });
 
+function isAdmin(event) {
+  try {
+    const claims = event.requestContext?.authorizer?.jwt?.claims;
+    if (!claims || !claims["custom:role"]) return false;
+    const roles = JSON.parse(claims["custom:role"]);
+    return Array.isArray(roles) && roles.includes("Admin");
+  } catch (_) {
+    return false;
+  }
+}
+
 export const handler = async (event) => {
   const headers = {
     'Access-Control-Allow-Origin': '*',
@@ -16,6 +27,10 @@ export const handler = async (event) => {
 
   if (event.httpMethod === 'OPTIONS' || event.requestContext?.http?.method === 'OPTIONS') {
     return { statusCode: 200, headers, body: '' };
+  }
+
+  if (!isAdmin(event)) {
+    return { statusCode: 403, headers, body: JSON.stringify({ message: "Not authorized" }) };
   }
 
   try {

--- a/lib/chatbot-api/functions/sync-schedule/lambda_function.py
+++ b/lib/chatbot-api/functions/sync-schedule/lambda_function.py
@@ -58,7 +58,7 @@ def _check_admin(event):
     try:
         claims = event["requestContext"]["authorizer"]["jwt"]["claims"]
         roles = json.loads(claims["custom:role"])
-        if not any("Admin" in role for role in roles):
+        if "Admin" not in roles:
             return False
     except Exception:
         return False

--- a/lib/chatbot-api/functions/websocket-chat/index.mjs
+++ b/lib/chatbot-api/functions/websocket-chat/index.mjs
@@ -399,7 +399,7 @@ const MAX_MESSAGE_LENGTH = 10_000;
  *   and the session has been saved. Errors are caught internally and sent
  *   to the client as <!ERROR!> frames.
  */
-const getUserResponse = async (id, requestJSON) => {
+const getUserResponse = async (id, requestJSON, authorizedUserId) => {
   try {
     const data = requestJSON?.data;
 
@@ -411,7 +411,10 @@ const getUserResponse = async (id, requestJSON) => {
     }
 
     let userMessage = data.userMessage;
-    const userId = data.user_id;
+    // Trust only the JWT-verified principal from the WS authorizer ($connect).
+    // Ignoring data.user_id prevents IDOR — a client cannot impersonate another
+    // user by changing the body field.
+    const userId = authorizedUserId;
     const sessionId = data.session_id;
     setCorrelationId(sessionId ?? "");
 
@@ -427,9 +430,15 @@ const getUserResponse = async (id, requestJSON) => {
       }));
       return;
     }
-    if (!userId || !sessionId) {
+    if (!userId) {
       await wsConnectionClient.send(new PostToConnectionCommand({
-        ConnectionId: id, Data: "<!ERROR!>: Missing user_id or session_id."
+        ConnectionId: id, Data: "<!ERROR!>: Unauthorized."
+      }));
+      return;
+    }
+    if (!sessionId) {
+      await wsConnectionClient.send(new PostToConnectionCommand({
+        ConnectionId: id, Data: "<!ERROR!>: Missing session_id."
       }));
       return;
     }
@@ -1334,9 +1343,16 @@ export const handler = async (event) => {
         return { statusCode: 200 };
       case '$default':
         return { 'action': 'Default Response Triggered' }
-      case "getChatbotResponse":
-        await getUserResponse(connectionId, body)
+      case "getChatbotResponse": {
+        // Pull the JWT-verified `sub` from the WS authorizer context that ran
+        // at $connect. API Gateway caches and propagates authorizer context to
+        // every route on the connection, so we always have a trusted user id
+        // here (no need to rely on the client-supplied body field).
+        const authorizer = event.requestContext.authorizer || {};
+        const authorizedUserId = authorizer.principalId || authorizer.userId || null;
+        await getUserResponse(connectionId, body, authorizedUserId)
         return { statusCode: 200 };
+      }
       default:
         return {
           statusCode: 404,  // 'Not Found' status code

--- a/lib/chatbot-api/functions/websocket-chat/index.test.mjs
+++ b/lib/chatbot-api/functions/websocket-chat/index.test.mjs
@@ -68,13 +68,18 @@ const CONN_ID = "test-conn";
 const MAX_LEN = 10_000;
 
 /** Build a valid getChatbotResponse event, with optional overrides in `data`. */
-function makeEvent(dataOverride = {}) {
+function makeEvent(dataOverride = {}, opts = {}) {
+  const principalId = opts.principalId === undefined ? "user1" : opts.principalId;
+  const authorizer = principalId === null ? {} : { principalId };
   return {
-    requestContext: { connectionId: CONN_ID, routeKey: "getChatbotResponse" },
+    requestContext: {
+      connectionId: CONN_ID,
+      routeKey: "getChatbotResponse",
+      authorizer,
+    },
     body: JSON.stringify({
       data: {
         userMessage: "Hello",
-        user_id:     "user1",
         session_id:  "sess1",
         chatHistory: [],
         ...dataOverride,
@@ -252,23 +257,28 @@ describe("getUserResponse input validation", () => {
     expect(lengthError).toBeUndefined();
   });
 
-  it("sends error when user_id is missing", async () => {
-    // JSON.stringify drops undefined keys, so user_id won't appear in the body
-    await handler(makeEvent({ user_id: undefined }));
+  it("sends error when the authorizer did not attach a principalId", async () => {
+    // No JWT-verified principal → connection should be rejected, regardless
+    // of what the client tries to put in data.user_id.
+    await handler(makeEvent({}, { principalId: null }));
     expect(mockWsSend).toHaveBeenCalledTimes(1);
-    expect(mockWsSend.mock.calls[0][0].Data).toContain("Missing user_id or session_id");
+    expect(mockWsSend.mock.calls[0][0].Data).toContain("Unauthorized");
   });
 
   it("sends error when session_id is missing", async () => {
     await handler(makeEvent({ session_id: undefined }));
     expect(mockWsSend).toHaveBeenCalledTimes(1);
-    expect(mockWsSend.mock.calls[0][0].Data).toContain("Missing user_id or session_id");
+    expect(mockWsSend.mock.calls[0][0].Data).toContain("Missing session_id");
   });
 
-  it("sends error when user_id is an empty string", async () => {
-    await handler(makeEvent({ user_id: "" }));
-    expect(mockWsSend).toHaveBeenCalledTimes(1);
-    expect(mockWsSend.mock.calls[0][0].Data).toContain("Missing user_id or session_id");
+  it("ignores a client-supplied user_id in favor of the authorizer principal", async () => {
+    // A client trying to impersonate another user by passing a different
+    // user_id in the body must not be able to. We assert the request
+    // proceeds past validation (no error from the user-id check) using the
+    // authorizer principal — KB_ID is set so the next code path runs.
+    await handler(makeEvent({ user_id: "victim-user" }));
+    const idError = mockWsSend.mock.calls.find(call => call[0].Data?.includes("Unauthorized"));
+    expect(idError).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
- IDOR-001: Session handler now extracts user_id from the API Gateway JWT authorizer claim (`sub`) when present, ignoring any value the client supplies in the body. The chat handler likewise reads the verified principal from the WebSocket authorizer context attached at $connect and passes it through to all session-handler Lambda invocations.

- PATH-001: Knowledge Base upload and eval test-cases upload handlers now reject unsafe characters, path traversal (`..`), and writes to system-managed keys (e.g. `metadata.txt`, `indexes/...`). Eval uploads are forced into the `test-cases/` prefix.

- AUTHZ-001: GET /user-feedback now requires admin via `ensure_admin`, closing a path that listed feedback for any authenticated user.

- AUTHZ-002: Added admin role checks to the start-llm-eval, eval-results-handler, and test-library-handler entry points.

- AUTHZ-003: source-presign now requires the requested key to use a known document extension and a safe character set, blocking arbitrary reads (e.g. of `metadata.txt`) from the KB bucket.

- AUTHZ-004: Replaced substring role matching with exact membership across all admin checks (Python `is_admin_request`, sync-schedule, kb-sync, delete-s3, get-s3, upload-s3, excel-index API) so role names like `AdminViewer` no longer satisfy the admin gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Bug Fixes**
  * Standardized and strengthened admin authorization checks across all API functions
  * Added authorization requirements to feedback and evaluation management endpoints
  * Enhanced user authentication to use verified JWT claims instead of client-supplied values
  * Added file upload validation to prevent path traversal attacks and unauthorized S3 access

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Burnes-Center/ai4impact-abe-chatbot-osd/pull/14)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->